### PR TITLE
Adding HODL&Cold Wallet Guides in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Please see the different Linked MD Files to find the Information you are searchi
 
 - [Create/Manage Cold Wallet](https://github.com/mwcproject/mwc-qt-wallet/blob/master/DOC/cold_wallet.md)
 
+- [Claim HODL Rewards](https://github.com/mwcproject/mwc-qt-wallet/blob/master/DOC/hodl_claims.md)
+
 
 ## Node Management
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Please see the different Linked MD Files to find the Information you are searchi
 
 - [Receive over Files using the CLI Wallet](guides/receive_file_cli-wallet.md)
 
+- [Receive over Files using a cold Wallet](https://github.com/mwcproject/mwc-qt-wallet/blob/master/DOC/cold_wallet.md#receivesend-mwc)
+
+
 ## Sending Funds
 
 - [Send over HTTP using the QT Wallet](guides/send_http_qt-wallet.md)
@@ -25,6 +28,8 @@ Please see the different Linked MD Files to find the Information you are searchi
 - [Send over Files using the QT Wallet](guides/send_file_qt-wallet.md)
 
 - [Send over Files using the CLI Wallet](guides/send_file_cli-wallet.md)
+
+- [Send over Files using a cold Wallet](https://github.com/mwcproject/mwc-qt-wallet/blob/master/DOC/cold_wallet.md#receivesend-mwc)
 
 ## Restore from Seed / Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Please see the different Linked MD Files to find the Information you are searchi
 
 - [Create/Manage Instances QT Wallet](guides/create_Instance_qt-wallet.md)
 
+- [Create/Manage Cold Wallet](https://github.com/mwcproject/mwc-qt-wallet/blob/master/DOC/cold_wallet.md)
+
+
 ## Node Management
 
 - [Build, Configuring, and Running the Node](https://github.com/mwcproject/mwc-node/blob/master/doc/build.md)


### PR DESCRIPTION
Simple PR to add a Link in the Readme pointing to the HODL_Claims Documentation as this might come up quite often now. 
Also Includes 2 older Commits adding Links to Cold Storage Guides.